### PR TITLE
T434: Fix RADIUS client authentication

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,12 @@
 vyos-pppoe-server (0.1.10+vyos2+current1) unstable; urgency=medium
 
+  [ Christian Poessinger ]
+  * Fix radiusclient folder after migration to libfreeradius-client2
+
+ -- Christian Poessinger <christian@poessinger.com>  Fri, 01 Dec 2017 18:00:00 +0100
+
+vyos-pppoe-server (0.1.10+vyos2+current1) unstable; urgency=medium
+
   [ Thomas Jepp ]
   * Fix build depends.
   * Change the runtime dependency from libradiusclient-ng2 to libfreeradius-client2.

--- a/debian/vyos-pppoe-server.postinst.in
+++ b/debian/vyos-pppoe-server.postinst.in
@@ -12,8 +12,8 @@ for init in pppoe-server; do
 done
 
 for cfg in /etc/ppp/secrets/chap-pppoe-server \
-           /etc/radiusclient-ng/radiusclient-pppoe.conf \
-           /etc/radiusclient-ng/servers-pppoe \
+           /etc/radiusclient/radiusclient-pppoe.conf \
+           /etc/radiusclient/servers-pppoe \
            /etc/ppp/pppoe-server-options; do
   mkdir -p ${cfg%/*}
   touch $cfg

--- a/lib/Vyatta/PPPoEServerConfig.pm
+++ b/lib/Vyatta/PPPoEServerConfig.pm
@@ -238,7 +238,7 @@ sub get_ppp_opts {
     if ($self->{_auth_mode} eq 'radius') {
         $rstr  = "plugin radius.so\n";
         $rstr .= "radius-config-file ";
-        $rstr .= " /etc/radiusclient-ng/radiusclient-pppoe.conf\n";
+        $rstr .= " /etc/radiusclient/radiusclient-pppoe.conf\n";
         if (defined($self->{_radius_interim})) {
             $rstr .= "default-interim $self->{_radius_interim}\n";
         }
@@ -303,13 +303,13 @@ sub get_radius_conf {
     $str .= "login_tries     4\n";
     $str .= "login_timeout   60\n";
     $str .= "nologin /etc/nologin\n";
-    $str .= "issue   /etc/radiusclient-ng/issue\n";
+    $str .= "issue   /etc/radiusclient/issue\n";
     $str .= ${authstr} . ${acctstr};
-    $str .= "servers         /etc/radiusclient-ng/servers-pppoe\n";
-    $str .= "dictionary      /etc/radiusclient-ng/dictionary-ravpn\n";
+    $str .= "servers         /etc/radiusclient/servers-pppoe\n";
+    $str .= "dictionary      /etc/radiusclient/dictionary-ravpn\n";
     $str .= "login_radius    /usr/sbin/login.radius\n";
     $str .= "seqfile         /var/run/radius.seq\n";
-    $str .= "mapfile         /etc/radiusclient-ng/port-id-map-ravpn\n";
+    $str .= "mapfile         /etc/radiusclient/port-id-map-ravpn\n";
     $str .= "default_realm\n";
     $str .= "radius_timeout  10\n";
     $str .= "radius_retries  3\n";

--- a/scripts/pppoe-radius-disconnect
+++ b/scripts/pppoe-radius-disconnect
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 # GET RADIUS INFORMATION
-open(RADFILE, '/etc/radiusclient-ng/servers-pppoe')
+open(RADFILE, '/etc/radiusclient/servers-pppoe')
   or die "$0: Cannot open PPPoE Radius Server Config: $!\n";
 my @radius;
 
@@ -22,7 +22,7 @@ my $radIP  = $radius[0];
 my $secret = $radius[1];
 my $port = $ARGV[0];
 
-my $d = new Net::Radius::Dictionary "/etc/radiusclient-ng/dictionary";
+my $d = new Net::Radius::Dictionary "/etc/radiusclient/dictionary";
 
 # flush after every write
 $| = 1;

--- a/scripts/update-pppoe-server.pl
+++ b/scripts/update-pppoe-server.pl
@@ -7,8 +7,8 @@ use Vyatta::PPPoEServerConfig;
 my $PPPOE_INIT        = '/etc/init.d/pppoe-server';
 my $FILE_CHAP_SECRETS = '/etc/ppp/secrets/chap-pppoe-server';
 my $FILE_PPPOE_OPTS   = '/etc/ppp/pppoe-server-options';
-my $FILE_RADIUS_CONF  = '/etc/radiusclient-ng/radiusclient-pppoe.conf';
-my $FILE_RADIUS_KEYS  = '/etc/radiusclient-ng/servers-pppoe';
+my $FILE_RADIUS_CONF  = '/etc/radiusclient/radiusclient-pppoe.conf';
+my $FILE_RADIUS_KEYS  = '/etc/radiusclient/servers-pppoe';
 
 my $config = new Vyatta::PPPoEServerConfig;
 my $oconfig = new Vyatta::PPPoEServerConfig;


### PR DESCRIPTION
Commit e30691eb7c08("Change the runtime dependency from libradiusclient-ng2 to
libfreeradius-client2.") changed the radiusclient which is used during
authentication. This change was required by the 'squeeze' -> 'jessie' upgrade.

"libradiusclient-ng2" used the configuration files from /etc/radiusclient-ng,
but "libfreeradius-client2" now uses "/etc/radiusclient".

Paths have been adjusted using:
  sed -i s@/etc/radiusclient-ng@/etc/radiusclient@g <file>